### PR TITLE
Use common boilerplate code for examples

### DIFF
--- a/examples/boilerplate.cpp
+++ b/examples/boilerplate.cpp
@@ -1,0 +1,66 @@
+#include <jsapi.h>
+
+#include <js/Initialization.h>
+
+#include "boilerplate.h"
+
+// This file contains boilerplate code used by a number of examples. Ideally
+// this should eventually become part of SpiderMonkey itself.
+
+// A standard set of ClassOps for globals. This includes hooks to resolve
+// standard JavaScript builtin types to give a more full-featured shell.
+const JSClassOps boilerplate::DefaultGlobalClassOps = {
+    nullptr,                         // addProperty
+    nullptr,                         // deleteProperty
+    nullptr,                         // enumerate
+    JS_NewEnumerateStandardClasses,  // newEnumerate
+    JS_ResolveStandardClass,         // resolve
+    JS_MayResolveStandardClass,      // mayResolve
+    nullptr,                         // finalize
+    nullptr,                         // call
+    nullptr,                         // hasInstance
+    nullptr,                         // construct
+    JS_GlobalObjectTraceHook         // trace
+};
+
+// Create a simple Global object. A global object is the top-level 'this' value
+// in a script and is required in order to compile or execute JavaScript.
+JSObject* boilerplate::CreateGlobal(JSContext* cx) {
+  JS::CompartmentOptions options;
+
+  static JSClass BoilerplateGlobalClass = {"BoilerplateGlobal",
+                                           JSCLASS_GLOBAL_FLAGS,
+                                           &boilerplate::DefaultGlobalClassOps};
+
+  return JS_NewGlobalObject(cx, &BoilerplateGlobalClass, nullptr,
+                            JS::FireOnNewGlobalHook, options);
+}
+
+// Initialize the JS environment, create a JSContext and run the example
+// function in that context. By default the self-hosting environment is
+// initialized as it is needed to run any JavaScript). If the 'initSelfHosting'
+// argument is false, we will not initialize self-hosting and instead leave
+// that to the caller.
+bool boilerplate::RunExample(bool (*task)(JSContext*), bool initSelfHosting) {
+  if (!JS_Init()) {
+    return false;
+  }
+
+  JSContext* cx = JS_NewContext(JS::DefaultHeapMaxBytes);
+  if (!cx) {
+    return false;
+  }
+
+  if (initSelfHosting && !JS::InitSelfHostedCode(cx)) {
+    return false;
+  }
+
+  if (!task(cx)) {
+    return false;
+  }
+
+  JS_DestroyContext(cx);
+  JS_ShutDown();
+
+  return true;
+}

--- a/examples/boilerplate.h
+++ b/examples/boilerplate.h
@@ -1,0 +1,13 @@
+#include <jsapi.h>
+
+// See 'boilerplate.cpp' for documentation.
+
+namespace boilerplate {
+
+extern const JSClassOps DefaultGlobalClassOps;
+
+JSObject* CreateGlobal(JSContext* cx);
+
+bool RunExample(bool (*task)(JSContext*), bool initSelfHosting = true);
+
+}  // namespace boilerplate

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -1,59 +1,28 @@
 #include <cstdio>
 
-#include <js/Initialization.h>
 #include <jsapi.h>
 
-/* This example illustrates the bare minimum you need to do to execute a
- * JavaScript program using embedded SpiderMonkey. It does no error handling and
- * simply exits if something goes wrong.
- *
- * To use the interpreter you need to create a context and a global object, and
- * do some setup on both of these. You also need to enter a "request" (lock on
- * the interpreter) and a "compartment" (environment within one global object)
- * before you can execute code. */
+#include "boilerplate.h"
 
-static JSClassOps globalOps = {nullptr,  // addProperty
-                               nullptr,  // deleteProperty
-                               nullptr,  // enumerate
-                               nullptr,  // newEnumerate
-                               nullptr,  // resolve
-                               nullptr,  // mayResolve
-                               nullptr,  // finalize
-                               nullptr,  // call
-                               nullptr,  // hasInstance
-                               nullptr,  // construct
-                               JS_GlobalObjectTraceHook};
-
-// The class of the global object.
-static JSClass globalClass = {"HelloWorldGlobal", JSCLASS_GLOBAL_FLAGS,
-                              &globalOps};
-
-static JSContext* CreateContext(void) {
-  JSContext* cx = JS_NewContext(8L * 1024 * 1024);
-  if (!cx) return nullptr;
-  if (!JS::InitSelfHostedCode(cx)) return nullptr;
-  return cx;
-}
-
-static JSObject* CreateGlobal(JSContext* cx) {
-  JS::CompartmentOptions options;
-  JS::RootedObject global(
-      cx, JS_NewGlobalObject(cx, &globalClass, nullptr, JS::FireOnNewGlobalHook,
-                             options));
-
-  // Add standard JavaScript classes to the global so we have a useful
-  // environment.
-  JSAutoCompartment ac(cx, global);
-  if (!JS_InitStandardClasses(cx, global)) return nullptr;
-
-  return global;
-}
+// This example illustrates the bare minimum you need to do to execute a
+// JavaScript program using embedded SpiderMonkey. It does no error handling and
+// simply exits if something goes wrong.
+//
+// See 'boilerplate.cpp' for the parts of this example that are reused in many
+// simple embedding examples.
+//
+// To use the interpreter you need to create a context and a global object, and
+// do some setup on both of these. You also need to enter a "request" (lock on
+// the interpreter) and a "compartment" (environment within one global object)
+// before you can execute code.
 
 static bool ExecuteCodePrintResult(JSContext* cx, const char* code) {
   JS::CompileOptions options(cx);
   options.setFileAndLine("noname", 1);
   JS::RootedValue rval(cx);
-  if (!JS::Evaluate(cx, options, code, strlen(code), &rval)) return false;
+  if (!JS::Evaluate(cx, options, code, strlen(code), &rval)) {
+    return false;
+  }
 
   // There are many ways to display an arbitrary value as a result. In this
   // case, we know that the value is a string because of the expression that we
@@ -62,11 +31,13 @@ static bool ExecuteCodePrintResult(JSContext* cx, const char* code) {
   return true;
 }
 
-static bool Run(JSContext* cx) {
+static bool HelloExample(JSContext* cx) {
   JSAutoRequest ar(cx);
 
-  JS::RootedObject global(cx, CreateGlobal(cx));
-  if (!global) return false;
+  JS::RootedObject global(cx, boilerplate::CreateGlobal(cx));
+  if (!global) {
+    return false;
+  }
 
   JSAutoCompartment ac(cx, global);
 
@@ -78,14 +49,8 @@ static bool Run(JSContext* cx) {
 }
 
 int main(int argc, const char* argv[]) {
-  if (!JS_Init()) return 1;
-
-  JSContext* cx = CreateContext();
-  if (!cx) return 1;
-
-  if (!Run(cx)) return 1;
-
-  JS_DestroyContext(cx);
-  JS_ShutDown();
+  if (!boilerplate::RunExample(HelloExample)) {
+    return 1;
+  }
   return 0;
 }

--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,6 @@ endif
 add_project_arguments(cxx.get_supported_arguments(test_warning_args),
     language: 'cpp')
 
-executable('hello', 'examples/hello.cpp', dependencies: spidermonkey)
+executable('hello', 'examples/hello.cpp', 'examples/boilerplate.cpp', dependencies: spidermonkey)
 executable('cookbook', 'examples/cookbook.cpp', dependencies: spidermonkey)
 executable('repl', 'examples/repl.cpp', dependencies: [spidermonkey, readline])

--- a/meson.build
+++ b/meson.build
@@ -65,5 +65,5 @@ add_project_arguments(cxx.get_supported_arguments(test_warning_args),
     language: 'cpp')
 
 executable('hello', 'examples/hello.cpp', 'examples/boilerplate.cpp', dependencies: spidermonkey)
-executable('cookbook', 'examples/cookbook.cpp', dependencies: spidermonkey)
+executable('cookbook', 'examples/cookbook.cpp', 'examples/boilerplate.cpp', dependencies: spidermonkey)
 executable('repl', 'examples/repl.cpp', dependencies: [spidermonkey, readline])

--- a/meson.build
+++ b/meson.build
@@ -66,4 +66,4 @@ add_project_arguments(cxx.get_supported_arguments(test_warning_args),
 
 executable('hello', 'examples/hello.cpp', 'examples/boilerplate.cpp', dependencies: spidermonkey)
 executable('cookbook', 'examples/cookbook.cpp', 'examples/boilerplate.cpp', dependencies: spidermonkey)
-executable('repl', 'examples/repl.cpp', dependencies: [spidermonkey, readline])
+executable('repl', 'examples/repl.cpp', 'examples/boilerplate.cpp', dependencies: [spidermonkey, readline])


### PR DESCRIPTION
This adds a boilerplate.cpp file and moves minimal initialization code to it to avoid duplication in examples.