### PR TITLE
Add JS::InitRealmStandardClasses to migration guide

### DIFF
--- a/docs/Migration Guide.md
+++ b/docs/Migration Guide.md
@@ -161,6 +161,7 @@ This is a non-exhaustive list of minor API changes and renames.
   objects no longer needs to use `JS_DATA_TO_FUNC_PTR()`.
   There is an appropriate overload to use instead.
 - `JS_GetGlobalForObject()` → `JS::GetNonCCWObjectGlobal()`
+- `JS_InitStandardClasses()` → `JS::InitRealmStandardClasses()`
 - `JS_NewArrayBuffer()` → `JS::NewArrayBuffer()`; ditto for
   `JS_NewArrayBufferWithContents()` and `JS_NewExternalArrayBuffer()`.
   In addition, `JS::NewExternalArrayBuffer()` has dropped support for


### PR DESCRIPTION
It was pointed out in https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/48#note_544066 that this was missing from the migration guide.