### PR TITLE
CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ env:
   CXX: clang++
   CC: clang
   LDFLAGS: -fuse-ld=lld
+  LD_LIBRARY_PATH: /usr/local/lib
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,10 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/mozjs.tar.bz2') }}
     - name: Build SpiderMonkey
       run: |
-        tar -xf mozjs.tar.bz2
-        cd mozjs*
+        mkdir -p /tmp/mozjs
+        tar -xf mozjs.tar.bz2 -C /tmp/mozjs
+        cd /tmp/mozjs
+        cd $(ls -d */|head -n 1)
         cd js/src
         autoconf2.13
         mkdir _build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Spidermonkey
+
+on:
+  push:
+    branches: [ esr78 ]
+  pull_request:
+    branches: [ esr78 ]
+
+env:
+  SHELL: /bin/bash
+  # ccache
+  CCACHE: ccache
+  # use clang/lld
+  CXX: clang++
+  CC: clang
+  LDFLAGS: -fuse-ld=lld
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install deps
+      run: |
+        sudo apt install autoconf2.13 ccache llvm clang lld -y
+    - uses: actions-rs/toolchain@v1
+      with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          default: true
+    - name: Get SM pkg
+      run: ./tools/get_sm_78.sh
+    - name: ccache cache files
+      uses: actions/cache@v1.1.0
+      with:
+        path: ~/.ccache
+        key: ${{ runner.os }}-${{ hashFiles('**/mozjs.tar.bz2') }}
+    - name: Build SpiderMonkey
+      run: |
+        tar -xf mozjs.tar.bz2
+        cd mozjs*
+        cd js/src
+        autoconf2.13
+        mkdir _build
+        cd _build
+        ../configure --disable-jemalloc --with-system-zlib \
+            --with-intl-api --enable-debug --enable-optimize
+        ccache -z
+        make
+        sudo make install
+        ccache -s
+    - name: Build Examples
+      run: |
+        meson _build
+        ninja -C _build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install deps
       run: |
-        sudo apt install autoconf2.13 ccache llvm clang lld -y
+        sudo apt install autoconf2.13 ccache llvm clang lld meson ninja-build -y
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [ esr78 ]
   pull_request:
     branches: [ esr78 ]
+  schedule: 
+    - cron: "10 10 10 * *"
 
 env:
   SHELL: /bin/bash
@@ -56,5 +58,5 @@ jobs:
         ccache -s
     - name: Build Examples
       run: |
-        meson _build
+        meson _build || cat _build/meson-logs/meson-log.txt
         ninja -C _build

--- a/tools/get_sm_78.sh
+++ b/tools/get_sm_78.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# get commit and appropriet mozjs tar
+repo=mozilla-esr78
+jobs=( $(curl "https://treeherder.mozilla.org/api/project/$repo/push/?full=true&count=10" | jq '.results[].id') )
+for i in "${jobs[@]}"
+do
+    task_id=$(curl "https://treeherder.mozilla.org/api/jobs/?push_id=$i" | jq -r '.results[] | select(.[] == "spidermonkey-sm-package-linux64/opt") | .[14]')
+    echo "Task id $task_id"
+    if [ ! -z "${task_id}" ]; then
+        tar_file=$(curl "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts" | jq -r '.artifacts[] | select(.name | contains("tar.bz2")) | .name')
+        echo "Tar at https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts/$tar_file"
+        curl -L --output mozjs.tar.bz2 "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts/$tar_file"
+        break
+    fi
+done


### PR DESCRIPTION
I added `get_sm_78` script, which downloads latest SM pkg from treeherder (mozilla-esr78 repo) using its API. 
Mozjs is then compiled and installed. If mozjs has same version as in previous run `ccache` should reduce build time.
On the next stage examples should be compiled.