### PR TITLE
Migration guide for ESR 91

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,12 @@ jobs:
           override: true
           default: true
     - name: Get SM pkg
-      run: ./tools/get_sm.sh
+      run: ./tools/get_sm_91.sh
     - name: ccache cache files
       uses: actions/cache@v1.1.0
       with:
         path: ~/.ccache
-        key: ${{ runner.os }}-${{ hashFiles('**/mozjs.tar.bz2') }}
+        key: ${{ runner.os }}-${{ hashFiles('**/mozjs.tar.xz') }}
     - name: Build SpiderMonkey
       run: |
         mkdir -p /tmp/mozjs

--- a/docs/Migration Guide.md
+++ b/docs/Migration Guide.md
@@ -148,6 +148,13 @@ On the returned value, check `isSome()` instead of `object()` to see if
 a property descriptor exists, and if it does, use `->` instead of `.` to
 access its methods.
 
+### Initialization ###
+
+Since SpiderMonkey 31 it's been required to call `JS_Init()` at the
+start of the program and `JS_ShutDown()` at the end.
+If you haven't been doing this in your code, now is the time to really
+do it, because it will otherwise trip a debug assertion.
+
 ### Headers ###
 
 There are now more headers which should be included separately in code

--- a/tools/get_sm_91.sh
+++ b/tools/get_sm_91.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# get commit and appropriate mozjs tar
+repo=mozilla-esr91
+jobs=( $(curl "https://treeherder.mozilla.org/api/project/$repo/push/?full=true&count=10" | jq '.results[].id') )
+for i in "${jobs[@]}"
+do
+    task_id=$(curl "https://treeherder.mozilla.org/api/jobs/?push_id=$i" | jq -r '.results[] | select(.[] == "spidermonkey-sm-package-linux64/opt") | .[14]')
+    echo "Task id $task_id"
+    if [ ! -z "${task_id}" ]; then
+        tar_file=$(curl "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts" | jq -r '.artifacts[] | select(.name | contains("tar.xz")) | .name')
+        echo "Tar at https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts/$tar_file"
+        curl -L --output mozjs.tar.xz "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts/$tar_file"
+        break
+    fi
+done


### PR DESCRIPTION
I've taken the migration notes and turned them into a full migration guide, adding recommendations and examples where applicable. I think after this we can make the `next` branch into `esr91` and start a new `next` branch!