### PR TITLE
add configure step to build instructions

### DIFF
--- a/docs/Building SpiderMonkey.md
+++ b/docs/Building SpiderMonkey.md
@@ -46,6 +46,8 @@ writable to you without superuser permissions, for example.
 
 ```sh
 cd js/src
+cp configure.in configure
+chmod u+x configure
 mkdir _build
 cd _build
 ../configure --disable-jemalloc --with-system-zlib \


### PR DESCRIPTION
I recently needed to compile from source ESR91 but this silly step was not there.