### PR TITLE
esr102 migration guide

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           override: true
           default: true
     - name: Get SM pkg
-      run: ./tools/get_sm_91.sh
+      run: ./tools/get_sm_102.sh
     - name: ccache cache files
       uses: actions/cache@v1.1.0
       with:

--- a/docs/Building SpiderMonkey.md
+++ b/docs/Building SpiderMonkey.md
@@ -4,15 +4,15 @@ Use these instructions to build your own copy of SpiderMonkey.
 
 ## Prerequisites ##
 
-You will need a **C++ compiler** that can handle the C++17 standard,
-**GNU Make**, **zlib**, and **libffi**.
+You will need a **C++ compiler** that can handle the C++17 standard, **Rust**
+version 1.59 or later, **GNU Make**, **zlib**, and **libffi**.
 These can usually be installed with a package manager.
 You will also need **Autoconf 2.13** (not any later version) which is
 also usually available through a package manager.
 The package will usually be called something like `autoconf2.13` rather
 than just `autoconf`.
 
-> **NOTE** SpiderMonkey also requires ICU of at least version 69.1, but
+> **NOTE** SpiderMonkey also requires ICU of at least version 71.1, but
 > it will build a bundled copy by default.
 > If you have a new enough copy installed on your system, you can add
 > `--with-system-icu` in the build instructions below, for a shorter
@@ -22,9 +22,18 @@ than just `autoconf`.
 
 Currently, the most reliable way to get the SpiderMonkey source code is
 to download the Firefox source.
-At the time of writing, the latest source for Firefox ESR 91, which
-contains the source for SpiderMonkey ESR 91, can be found here:
-https://ftp.mozilla.org/pub/firefox/releases/91.0esr/source/
+At the time of writing, the latest source for Firefox ESR 102, which
+contains the source for SpiderMonkey ESR 102, can be found here:
+https://ftp.mozilla.org/pub/firefox/releases/102.1.0esr/source/
+
+This version is broken for embedder builds so you will need to either
+wait for version 102.2.0 or patch the 102.1.0 source with the fixes for
+the following bugs:
+
+ - [1776254 - Cannot build library for SM embedding examples, missing
+   ProfilingCategoryList.h](https://bugzilla.mozilla.org/show_bug.cgi?id=1776254)
+ - [1780857 - Embedder build broken in js/public/Debug.h if DEBUG not
+   defined](https://bugzilla.mozilla.org/show_bug.cgi?id=1780857)
 
 The ESR releases have a major release approximately once a year with
 security patches released throughout the year.

--- a/examples/repl.cpp
+++ b/examples/repl.cpp
@@ -32,12 +32,14 @@
  * Windows you may have to set your terminal's codepage to UTF-8. */
 
 class ReplGlobal {
+  enum Slots { GlobalSlot, SlotCount };
+
   bool m_shouldQuit : 1;
 
   ReplGlobal(void) : m_shouldQuit(false) {}
 
   static ReplGlobal* priv(JSObject* global) {
-    auto* retval = static_cast<ReplGlobal*>(JS::GetPrivate(global));
+    auto* retval = JS::GetMaybePtrFromReservedSlot<ReplGlobal>(global, GlobalSlot);
     assert(retval);
     return retval;
   }
@@ -67,9 +69,11 @@ class ReplGlobal {
 constexpr JSFunctionSpec ReplGlobal::functions[];
 
 /* The class of the global object. */
-const JSClass ReplGlobal::klass = {"ReplGlobal",
-                                   JSCLASS_GLOBAL_FLAGS | JSCLASS_HAS_PRIVATE,
-                                   &JS::DefaultGlobalClassOps};
+const JSClass ReplGlobal::klass = {
+    "ReplGlobal",
+    JSCLASS_GLOBAL_FLAGS | JSCLASS_HAS_RESERVED_SLOTS(ReplGlobal::SlotCount),
+    &JS::DefaultGlobalClassOps
+};
 
 std::string FormatString(JSContext* cx, JS::HandleString string) {
   std::string buf = "\"";
@@ -135,7 +139,7 @@ JSObject* ReplGlobal::create(JSContext* cx) {
                                              JS::FireOnNewGlobalHook, options));
 
   ReplGlobal* priv = new ReplGlobal();
-  JS::SetPrivate(global, priv);
+  JS::SetReservedSlot(global, GlobalSlot, JS::PrivateValue(priv));
 
   // Define any extra global functions that we want in our environment.
   JSAutoRealm ar(cx, global);

--- a/examples/resolve.cpp
+++ b/examples/resolve.cpp
@@ -29,6 +29,8 @@ namespace zlib {
  * and a `checksum` property. */
 
 class Crc {
+  enum Slots { CrcSlot, SlotCount };
+
   unsigned long m_crc;
 
   Crc(void) : m_crc(zlib::crc32(0L, nullptr, 0)) {}
@@ -67,7 +69,7 @@ class Crc {
   }
 
   static Crc* getPriv(JSObject* obj) {
-    return static_cast<Crc*>(JS::GetPrivate(obj));
+    return JS::GetMaybePtrFromReservedSlot<Crc>(obj, CrcSlot);
   }
 
   static bool isPrototype(JSObject* obj) { return getPriv(obj) == nullptr; }
@@ -94,7 +96,7 @@ class Crc {
     if (!newObj) return false;
 
     Crc* priv = new Crc();
-    JS::SetPrivate(newObj, priv);
+    JS::SetReservedSlot(newObj, CrcSlot, JS::PrivateValue(priv));
 
     args.rval().setObject(*newObj);
     return true;
@@ -184,7 +186,7 @@ class Crc {
     Crc* priv = getPriv(obj);
     if (priv) {
       delete priv;
-      JS::SetPrivate(obj, nullptr);
+      JS::SetReservedSlot(obj, CrcSlot, JS::UndefinedValue());
     }
   }
 
@@ -206,7 +208,7 @@ class Crc {
 
   static constexpr JSClass klass = {
       "Crc",
-      JSCLASS_HAS_PRIVATE | JSCLASS_BACKGROUND_FINALIZE,
+      JSCLASS_HAS_RESERVED_SLOTS(SlotCount) | JSCLASS_BACKGROUND_FINALIZE,
       &Crc::classOps,
   };
 
@@ -229,7 +231,7 @@ class Crc {
 
     // Here's how we tell the prototype apart from instances. The private
     // pointer will be null.
-    JS::SetPrivate(proto, nullptr);
+    JS::SetReservedSlot(proto, CrcSlot, JS::UndefinedValue());
     return true;
   }
 };

--- a/examples/resolve.cpp
+++ b/examples/resolve.cpp
@@ -146,12 +146,12 @@ class Crc {
       return true;
     }
 
-    if (!JSID_IS_STRING(id)) {
+    if (!id.isString()) {
       *resolved = false;
       return true;
     }
 
-    JSLinearString* str = JSID_TO_LINEAR_STRING(id);
+    JSLinearString* str = id.toLinearString();
 
     if (JS_LinearStringEqualsAscii(str, "update")) {
       if (!JS_DefineFunctionById(cx, obj, id, &Crc::update, 1,
@@ -175,14 +175,14 @@ class Crc {
 
   static bool mayResolve(const JSAtomState& names, jsid id,
                          JSObject* maybeObj) {
-    if (!JSID_IS_STRING(id)) return false;
+    if (!id.isString()) return false;
 
-    JSLinearString* str = JSID_TO_LINEAR_STRING(id);
+    JSLinearString* str = id.toLinearString();
     return JS_LinearStringEqualsAscii(str, "update") ||
            JS_LinearStringEqualsAscii(str, "checksum");
   }
 
-  static void finalize(JSFreeOp* fop, JSObject* obj) {
+  static void finalize(JS::GCContext* gcx, JSObject* obj) {
     Crc* priv = getPriv(obj);
     if (priv) {
       delete priv;

--- a/examples/resolve.cpp
+++ b/examples/resolve.cpp
@@ -201,7 +201,6 @@ class Crc {
       &Crc::mayResolve,
       &Crc::finalize,
       nullptr,  // call
-      nullptr,  // hasInstance
       nullptr,  // construct
       nullptr,  // trace
   };

--- a/examples/tracing.cpp
+++ b/examples/tracing.cpp
@@ -105,7 +105,7 @@ mozilla::Maybe<JS::PersistentRooted<SafeBox>> globalMaybeSafe;
 
 static bool GlobalRootExample(JSContext* cx) {
   // Initialize the root with cx and allocate a fresh SafeBox.
-  globalPtrSafe.init(cx, new SafeBox);
+  globalPtrSafe.init(cx, js::MakeUnique<SafeBox>());
 
   // If we want to avoid a heap allocation, we can wrap the PersistentRooted in
   // a Maybe. When we emplace the variable, we pass 'cx' for the constructor of

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('spidermonkey-embedding-examples', 'cpp', version: 'esr91',
+project('spidermonkey-embedding-examples', 'cpp', version: 'esr102',
     meson_version: '>= 0.43.0',
     default_options: ['cpp_std=c++17', 'warning_level=3'])
 
@@ -7,7 +7,7 @@ cxx = meson.get_compiler('cpp')
 args = []
 
 zlib = dependency('zlib')  # (is already a SpiderMonkey dependency)
-spidermonkey = dependency('mozjs-91')
+spidermonkey = dependency('mozjs-102')
 readline = cxx.find_library('readline')
 
 # Check if SpiderMonkey was compiled with --enable-debug. If this is the case,

--- a/tools/get_sm_102.sh
+++ b/tools/get_sm_102.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# get commit and appropriate mozjs tar
+repo=mozilla-esr102
+jobs=( $(curl "https://treeherder.mozilla.org/api/project/$repo/push/?full=true&count=10" | jq '.results[].id') )
+for i in "${jobs[@]}"
+do
+    task_id=$(curl "https://treeherder.mozilla.org/api/jobs/?push_id=$i" | jq -r '.results[] | select(.[] == "spidermonkey-sm-package-linux64/opt") | .[14]')
+    echo "Task id $task_id"
+    if [ ! -z "${task_id}" ]; then
+        tar_file=$(curl "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts" | jq -r '.artifacts[] | select(.name | contains("tar.xz")) | .name')
+        echo "Tar at https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts/$tar_file"
+        curl -L --output mozjs.tar.xz "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/$task_id/runs/0/artifacts/$tar_file"
+        break
+    fi
+done


### PR DESCRIPTION
This PR ports the `next` branch to esr102. I think once this is reviewed, we can cut an official `esr102` branch and make it the default branch.