### PR TITLE
Migration from ESR 115 to 128

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains documentation and examples for people who want
 to embed the SpiderMonkey JavaScript engine.
 
-The information on this `esr102` branch applies to SpiderMonkey 102.x, an
+The information on this `esr128` branch applies to SpiderMonkey 128.x, an
 Extended Support Release (ESR).
 For other versions of SpiderMonkey, check the other branches: `next` for
 information that will apply in the next as-yet-unreleased ESR, or

--- a/docs/Building SpiderMonkey.md
+++ b/docs/Building SpiderMonkey.md
@@ -5,7 +5,7 @@ Use these instructions to build your own copy of SpiderMonkey.
 ## Prerequisites ##
 
 You will need a **C++ compiler** that can handle the C++17 standard,
-**Rust** version [1.66][minimum-rust-version] or later, **GNU Make**,
+**Rust** version [1.76][minimum-rust-version] or later, **GNU Make**,
 **zlib**, and **libffi**.
 These can usually be installed with a package manager.
 
@@ -16,16 +16,16 @@ These can usually be installed with a package manager.
 > `--with-system-icu` in the build instructions below, for a shorter
 > build time.
 
-[minimum-rust-version]: https://searchfox.org/mozilla-esr115/rev/61b47de1faebf23626e519b2464b461589fbea3e/python/mozboot/mozboot/util.py#14
-[minimum-icu-version]: https://searchfox.org/mozilla-esr115/rev/61b47de1faebf23626e519b2464b461589fbea3e/js/moz.configure#1107
+[minimum-rust-version]: https://searchfox.org/mozilla-esr128/rev/2d28d1b9e757a35095de45c818a0432e031f339d/python/mozboot/mozboot/util.py#14
+[minimum-icu-version]: https://searchfox.org/mozilla-esr128/rev/2d28d1b9e757a35095de45c818a0432e031f339d/js/moz.configure#1308
 
 ## Getting the source code ##
 
 Currently, the most reliable way to get the SpiderMonkey source code is
 to download the Firefox source.
-At the time of writing, the latest source for Firefox ESR 115, which
-contains the source for SpiderMonkey ESR 115, can be found here:
-https://ftp.mozilla.org/pub/firefox/releases/115.1.0esr/source/
+At the time of writing, the latest source for Firefox ESR 128, which
+contains the source for SpiderMonkey ESR 128, can be found here:
+https://ftp.mozilla.org/pub/firefox/releases/128.1.0esr/source/
 
 The ESR releases have a major release approximately once a year with
 security patches released throughout the year.

--- a/examples/cookbook.cpp
+++ b/examples/cookbook.cpp
@@ -6,6 +6,7 @@
 #include <mozilla/Unused.h>
 
 #include <js/Array.h>
+#include <js/ColumnNumber.h>
 #include <js/CompilationAndEvaluation.h>
 #include <js/Conversions.h>
 #include <js/Initialization.h>
@@ -352,9 +353,10 @@ static bool ThrowValue(JSContext* cx, JS::HandleValue exc) {
  *
  * return ThrowError(cx, global, message, __FILE__, __LINE__, column);
  */
-static bool ThrowError(JSContext* cx, JS::HandleObject global,
-                       const char* message, const char* filename,
-                       int32_t lineno, int32_t colno = 0) {
+static bool ThrowError(
+    JSContext* cx, JS::HandleObject global, const char* message,
+    const char* filename, int32_t lineno,
+    JS::ColumnNumberOneOrigin colno = JS::ColumnNumberOneOrigin{1}) {
   JS::RootedString messageStr(cx, JS_NewStringCopyZ(cx, message));
   if (!messageStr) return false;
   JS::RootedString filenameStr(cx, JS_NewStringCopyZ(cx, filename));

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('spidermonkey-embedding-examples', 'cpp', version: 'esr115',
+project('spidermonkey-embedding-examples', 'cpp', version: 'esr128',
     meson_version: '>= 0.43.0',
     default_options: ['cpp_std=c++20', 'warning_level=3'])
 
@@ -7,7 +7,7 @@ cxx = meson.get_compiler('cpp')
 args = []
 
 zlib = dependency('zlib')  # (is already a SpiderMonkey dependency)
-spidermonkey = dependency('mozjs-127a1')
+spidermonkey = dependency('mozjs-128')
 readline = cxx.find_library('readline')
 
 # Check if SpiderMonkey was compiled with --enable-debug. If this is the case,


### PR DESCRIPTION
Includes updated build instructions and a migration guide. Only one of the examples needs to be updated, with the new column number API; everything else builds as is.