### PR TITLE
Change version from ESR 140.0 to ESR 140.7.0 in doc

### DIFF
--- a/docs/Building SpiderMonkey.md
+++ b/docs/Building SpiderMonkey.md
@@ -25,7 +25,7 @@ Currently, the most reliable way to get the SpiderMonkey source code is
 to download the Firefox source.
 At the time of writing, the latest source for Firefox ESR 140, which
 contains the source for SpiderMonkey ESR 140, can be found here:
-https://ftp.mozilla.org/pub/firefox/releases/140.0esr/source/
+https://ftp.mozilla.org/pub/firefox/releases/140.7.0esr/source/
 
 The ESR releases have a major release approximately once a year with
 security patches released throughout the year.


### PR DESCRIPTION
ESR 140.0 may not be usable due to this bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1973993

which is fixed in ESR 140.7.0.